### PR TITLE
HTTP Request Body to WASI `stdin`

### DIFF
--- a/examples/wasm_modules/python-scripts/http_request_viewer.py
+++ b/examples/wasm_modules/python-scripts/http_request_viewer.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+
+import os, sys, subprocess, cgi, cgitb, fileinput
+
+# Create instance of FieldStorage 
+form = cgi.FieldStorage() 
+
+print("Content-Type: text/html")
+print("")
+
+print("<!DOCTYPE html><HTML><HEAD>")
+print("<TITLE>HTTP Request Viewer</TITLE><meta charset=\"utf-8\">")
+print("<style>body{font-family:-apple-system,BlinkMacSystemFont,avenir next,avenir,segoe ui,helvetica neue,helvetica,Cantarell,Ubuntu,roboto,noto,arial,sans-serif;background-color:#fff;margin:0}main{margin-bottom:0.1rem}header{padding:0.1rem;background:linear-gradient(60deg,#d1ebff,#99c2ff);margin-bottom:0.1rem}.content{max-width:1300px;margin:0 auto;padding:0 1rem}h1{text-align:center}h2{border-bottom:1px solid #aaa;padding-bottom:.5rem}pre{padding:0.5rem;border:1px solid #ccc;font-size:.9rem;border-radius:5px;background-color:#f6f6f6;font-family:Menlo,Consolas,Monaco,Liberation Mono,Lucida Console,monospace;white-space:pre-wrap}.var{font-weight:700}</style>")
+print("</HEAD><BODY><main>")
+print('<header><h1>🌐 HTTP Request Viewer 🔍</h1></header>')
+print('<div class="content">')
+
+# Platform
+print('<h2>Platform</h2>')
+print('<pre><code>', end='')
+print('<span class="var">sys.platform = ' + '</span>'+ sys.platform)
+print('</code></pre>')
+
+# Args
+print('<h2>Arguments</h2>')
+print('<pre><code>sys.argv:', sys.argv, '</code></pre>')
+
+# Env Vars
+print('<h2>Environment Variables</h2>')
+print('<pre><code>', end='')
+for k, v in sorted(os.environ.items()):
+    print('<span class="var">'+ k + '=' + '</span>'+ v)
+print('</code></pre>')
+
+# URL Parameters
+print('<h2>URL Parameters</h2>')
+print('<pre><code>', end='')
+for k in form.keys():
+    print('<span class="var">'+ k + ' = ' + '</span>'+ form.getvalue(k))
+print('</code></pre>')
+
+# Stdin
+print('<h2>Stdin</h2>')
+print('<pre><code>', end='')
+for line in fileinput.input():
+    print(line)
+print('</code></pre>')
+
+
+print("</div></main></BODY></HTML>")

--- a/mod_wasm/httpd.conf
+++ b/mod_wasm/httpd.conf
@@ -261,6 +261,20 @@ LoadModule wasm_module modules/mod_wasm.so
     # WasmEnableCGI On
     ##################################################################
 
+    ###################################################################
+    #                        HTTP Request Viewer                      #          
+    ###################################################################
+    # WasmRoot   /home/ubuntu/Home/Workspace/VMware/mod_wasm/httpd
+    # WasmModule python3.11.wasm
+    # WasmArg    /VMware/mod_wasm/httpd/dist/cgi-bin/http_request_viewer.py
+    # WasmEnv    PYTHONHOME /VMware/mod_wasm_ext/wagi-python/opt/wasi-python/lib/python3.11
+    # WasmEnv    PYTHONPATH /VMware/mod_wasm_ext/wagi-python/opt/wasi-python/lib/python3.11
+    # WasmDir    /tmp
+    # WasmMapDir /VMware /home/ubuntu/Home/Workspace/VMware
+    # WasmMapDir /cgi-bin /home/ubuntu/Home/Workspace/VMware/mod_wasm/httpd/dist/cgi-bin
+    # WasmEnableCGI On
+    ##################################################################
+
 </IfModule>
 
 

--- a/mod_wasm/mod_wasm.c
+++ b/mod_wasm/mod_wasm.c
@@ -265,8 +265,11 @@ static void populate_runtime_with_config_defined_envs(x_cfg *cfg)
 
 
 /*
- * This function reads the HTTP Body Request
+ * This function reads the HTTP Request Body
  * 
+ * r: request
+ * rbuff: buffer to where the body will be allocated
+ * size: size of the buffer allocated
  * 
  * More info:
  *  - https://httpd.apache.org/docs/trunk/developer/modguide.html (section: "Reading the request body into memory")

--- a/mod_wasm/mod_wasm.c
+++ b/mod_wasm/mod_wasm.c
@@ -278,14 +278,12 @@ static int content_handler(request_rec *r)
     // workers/threads.
     //
     // This reset to initial state is crucial when the module is
-    // behaving as a CGI module, because arguments and environnent
-    // variables might be set depending on the data of the
+    // behaving as a CGI module, because environnent variables
+    // might be set depending on the data of the
     // request. However, the user might have also added some static
     // arguments and environment variables to the Apache
     // configuration.
-    wasm_config_clear_args();
     wasm_config_clear_envs();
-    populate_runtime_with_config_defined_args(dcfg);
     populate_runtime_with_config_defined_envs(dcfg);
 
     if (dcfg->bEnableCGI) {

--- a/mod_wasm/mod_wasm.c
+++ b/mod_wasm/mod_wasm.c
@@ -424,7 +424,7 @@ static const char *wasm_directive_WasmEnv(cmd_parms *cmd, void *mconfig, const c
 static const char *wasm_directive_WasmDir(cmd_parms *cmd, void *mconfig, const char *word1)
 {
     x_cfg *cfg = (x_cfg *) mconfig;
-    wasm_config_set_dir(word1);
+    wasm_config_add_dir(word1);
     return NULL;
 }
 

--- a/mod_wasm/mod_wasm.c
+++ b/mod_wasm/mod_wasm.c
@@ -36,6 +36,14 @@
 /*--------------------------------------------------------------------------*/
 
 /**
+  * Maximum number of bytes to allocate the body from an HTTP Request.
+  *
+  * 16KB (16*1024 = 16386)
+  *
+  */
+#define CONFIG_HTTP_REQUEST_BODY_MAX 16386
+
+/**
   * Maximum number of arguments specified in the static configuration.
   *
   * If the user tries to set more arguments on the Apache
@@ -254,6 +262,56 @@ static void populate_runtime_with_config_defined_envs(x_cfg *cfg)
     }
 }
 
+
+
+/*
+ * This function reads the HTTP Body Request
+ * 
+ * 
+ * More info:
+ *  - https://httpd.apache.org/docs/trunk/developer/modguide.html (section: "Reading the request body into memory")
+ *  - https://docstore.mik.ua/orelly/apache_mod/139.htm 
+ */
+static int read_http_request_body(request_rec *r, const char **rbuf, apr_off_t *size)
+{
+    int rc = DECLINED; // return code ('DECLINED' by default)
+
+    // setup the client to allow Apache to read the request body
+    if ( (rc = ap_setup_client_block(r, REQUEST_CHUNKED_ERROR)) != OK )
+    {
+        return rc;
+    }
+
+
+    // can we read or abort?
+    if ( ap_should_client_block(r) )
+    {
+        char argsbuffer[CONFIG_HTTP_REQUEST_BODY_MAX];
+        apr_off_t rsize, len_read, rpos = 0;
+        apr_off_t length = r->remaining;
+
+        *rbuf = (const char *) apr_pcalloc( r->pool, (apr_size_t)(length + 1) );
+        *size = length;
+        while ( (len_read = ap_get_client_block(r, argsbuffer, sizeof(argsbuffer))) > 0 )
+        {
+            if ( (rpos + len_read) > length )
+            {
+                rsize = length - rpos;
+            }
+            else
+            {
+                rsize = len_read;
+            }
+
+            memcpy( (char *)*rbuf + rpos, argsbuffer, (size_t)rsize );
+            rpos += rsize;
+        }
+    }
+
+    return rc;
+}
+
+
 /*
  * Content handler
  */
@@ -294,7 +352,20 @@ static int content_handler(request_rec *r)
       ap_add_common_vars(r);
       ap_add_cgi_vars(r);
       apr_table_do(_wasm_config_add_env, NULL, r->subprocess_env, NULL);
+
+      // read request body and store it as WASI Stdin
+      apr_off_t body_size = 0;
+      const char* body_buffer;
+
+      if ( read_http_request_body(r, &body_buffer, &body_size) != OK ) {
+        trace_nocontext(NULL, __FILE__, __LINE__, "content_handler() - ERROR! Couldn't read HTTP Request Body!");
+      }
+      else 
+      {
+        wasm_config_set_stdin(body_buffer, body_size);
+      }
     }
+
 
     // run Wasm module
     const char* module_response = wasm_runtime_run_module();

--- a/mod_wasm/mod_wasm.c
+++ b/mod_wasm/mod_wasm.c
@@ -278,12 +278,14 @@ static int content_handler(request_rec *r)
     // workers/threads.
     //
     // This reset to initial state is crucial when the module is
-    // behaving as a CGI module, because environnent variables
-    // might be set depending on the data of the
+    // behaving as a CGI module, because arguments and environnent
+    // variables might be set depending on the data of the
     // request. However, the user might have also added some static
     // arguments and environment variables to the Apache
     // configuration.
+    wasm_config_clear_args();
     wasm_config_clear_envs();
+    populate_runtime_with_config_defined_args(dcfg);
     populate_runtime_with_config_defined_envs(dcfg);
 
     if (dcfg->bEnableCGI) {

--- a/wasm_runtime/src/c_api.rs
+++ b/wasm_runtime/src/c_api.rs
@@ -126,7 +126,7 @@ pub extern "C" fn wasm_config_add_env(env: *const c_char, value: *const c_char) 
 
 }
 
-/// Clears all WASI propened dirs for the Wasm module
+/// Clears all WASI preopened dirs for the Wasm module
 #[no_mangle]
 pub extern "C" fn wasm_config_clear_dirs() {
     WASM_RUNTIME_CONFIG.write()
@@ -215,7 +215,11 @@ pub extern "C" fn wasm_runtime_init_module() -> *const c_char {
     str_to_c_char(&return_msg)
 }
 
-
+/// Run the Wasm module
+///
+/// Returns a string with the stdout from the module if execution was succesfuly.
+/// Otherwise, trace the error and returns the string explaining the error.
+///
 #[no_mangle]
 pub extern "C" fn wasm_runtime_run_module() -> *const c_char {
     let result = match run_module() {
@@ -231,6 +235,12 @@ pub extern "C" fn wasm_runtime_run_module() -> *const c_char {
 }
 
 
+/// Returns raw pointer's ownership
+///
+/// After returning a const *char pointer from Rust-world to the C-world, when such a pointer is not going to be used any more, 
+/// C-world MUST invoke this function in order to Rust-world being able to deallocate the memory.
+/// Otherwise, memory will leak.
+///
 #[no_mangle]
 pub extern "C" fn return_const_char_ownership(ptr: *const c_char) {
     deallocate_cstring(ptr);

--- a/wasm_runtime/src/c_api.rs
+++ b/wasm_runtime/src/c_api.rs
@@ -126,6 +126,14 @@ pub extern "C" fn wasm_config_add_env(env: *const c_char, value: *const c_char) 
 
 }
 
+/// Clears all WASI propened dirs for the Wasm module
+#[no_mangle]
+pub extern "C" fn wasm_config_clear_dirs() {
+    WASM_RUNTIME_CONFIG.write()
+        .expect("ERROR! Poisoned RwLock WASM_RUNTIME_CONFIG on write()")
+        .wasi_dirs
+        .clear();
+}
 
 /// Add a WASI preopen dir for the Wasm module
 ///
@@ -150,6 +158,14 @@ pub extern "C" fn wasm_config_set_dir(dir: *const c_char) {
         .push(dir_str.to_string());
 }
 
+/// Clears all WASI propened dirs with mapping for the Wasm module
+#[no_mangle]
+pub extern "C" fn wasm_config_clear_mapdirs() {
+    WASM_RUNTIME_CONFIG.write()
+        .expect("ERROR! Poisoned RwLock WASM_RUNTIME_CONFIG on write()")
+        .wasi_mapdirs
+        .clear();
+}
 
 /// Add a WASI preopen dir with mapping for the Wasm module
 ///
@@ -177,14 +193,6 @@ pub extern "C" fn wasm_config_add_mapdir(map: *const c_char, dir: *const c_char)
         .push((map_str.to_string(), dir_str.to_string()));
 }
 
-/// Clears all WASI propened dirs for the Wasm module
-#[no_mangle]
-pub extern "C" fn wasm_config_clear_mapdirs() {
-    WASM_RUNTIME_CONFIG.write()
-        .expect("ERROR! Poisoned RwLock WASM_RUNTIME_CONFIG on write()")
-        .wasi_mapdirs
-        .clear();
-}
 
 /// Initialize the Wasm module
 ///

--- a/wasm_runtime/src/c_api.rs
+++ b/wasm_runtime/src/c_api.rs
@@ -146,10 +146,10 @@ pub extern "C" fn wasm_config_clear_dirs() {
 /// # Examples (C Code)
 ///
 /// ```
-/// wasm_config_set_dir("/tmp");
+/// wasm_config_add_dir("/tmp");
 /// ```
 #[no_mangle]
-pub extern "C" fn wasm_config_set_dir(dir: *const c_char) {
+pub extern "C" fn wasm_config_add_dir(dir: *const c_char) {
     let dir_str   = const_c_char_to_str(dir);
 
     WASM_RUNTIME_CONFIG.write()

--- a/wasm_runtime/src/config.rs
+++ b/wasm_runtime/src/config.rs
@@ -18,6 +18,7 @@ pub struct WasmRuntimeConfig {
     pub wasi_envs:    Vec<(String, String)>,
     pub wasi_dirs:    Vec<String>,
     pub wasi_mapdirs: Vec<(String, String)>,
+    pub wasi_stdin:   Vec<u8>,
 }
 
 // The following static variable is used to achieve a global, mutable and thread-safe shareable state.
@@ -34,6 +35,7 @@ pub static WASM_RUNTIME_CONFIG: Lazy<RwLock<WasmRuntimeConfig>> = Lazy::new(|| {
         wasi_envs:    Vec::new(),
         wasi_dirs:    Vec::new(),
         wasi_mapdirs: Vec::new(),
+        wasi_stdin:   Vec::new(),
     };
 
     RwLock::new(data)

--- a/wasm_runtime/src/ffi_utils.rs
+++ b/wasm_runtime/src/ffi_utils.rs
@@ -36,7 +36,7 @@ pub fn const_c_char_to_str(const_c_char: *const c_char) -> &'static str {
 // Two steps:
 //   1) From &str to CString (ensuring null-termination)
 //   2) From CString into *const c_char (C char pointer) via CString::into_raw()
-//      This sencond step will trasnfer ownership of the pointer to the C world.
+//      This second step will transfer ownership of the pointer to the C world.
 //      C must callback Rust to deallocate such a CString raw pointer via CString::from_raw.
 //      Otherwise, the CString will leak the memory used.
 //      More info at: https://doc.rust-lang.org/alloc/ffi/struct.CString.html#method.from_raw

--- a/wasm_runtime/src/wasm_runtime.h
+++ b/wasm_runtime/src/wasm_runtime.h
@@ -82,6 +82,11 @@ void wasm_config_add_env(const char *env,
                          const char *value);
 
 /**
+ * Clears all WASI preopened dirs for the Wasm module
+ */
+void wasm_config_clear_dirs(void);
+
+/**
  * Add a WASI preopen dir for the Wasm module
  *
  * Due to String management differences between C and Rust, this function uses `unsafe {}` code.
@@ -93,10 +98,15 @@ void wasm_config_add_env(const char *env,
  * # Examples (C Code)
  *
  * ```
- * wasm_config_set_dir("/tmp");
+ * wasm_config_add_dir("/tmp");
  * ```
  */
-void wasm_config_set_dir(const char *dir);
+void wasm_config_add_dir(const char *dir);
+
+/**
+ * Clears all WASI propened dirs with mapping for the Wasm module
+ */
+void wasm_config_clear_mapdirs(void);
 
 /**
  * Add a WASI preopen dir with mapping for the Wasm module
@@ -132,6 +142,21 @@ void wasm_config_clear_mapdirs(void);
  */
 const char *wasm_runtime_init_module(void);
 
+/**
+ * Run the Wasm module
+ *
+ * Returns a string with the stdout from the module if execution was succesfuly.
+ * Otherwise, trace the error and returns the string explaining the error.
+ *
+ */
 const char *wasm_runtime_run_module(void);
 
+/**
+ * Returns raw pointer's ownership
+ *
+ * After returning a const *char pointer from Rust-world to the C-world, when such a pointer is not going to be used any more,
+ * C-world MUST invoke this function in order to Rust-world being able to deallocate the memory.
+ * Otherwise, memory will leak.
+ *
+ */
 void return_const_char_ownership(const char *ptr);

--- a/wasm_runtime/src/wasm_runtime.h
+++ b/wasm_runtime/src/wasm_runtime.h
@@ -129,9 +129,22 @@ void wasm_config_add_mapdir(const char *map,
                             const char *dir);
 
 /**
- * Clears all WASI propened dirs for the Wasm module
+ * Set the WASI stdin for the Wasm module
+ *
+ * Due to String management differences between C and Rust, this function uses `unsafe {}` code.
+ * So `filename` must be a valid pointer to a null-terminated C char array. Otherwise, code might panic.
+ *
+ * In addition, `filename` must contain valid ASCII chars that can be converted into UTF-8 encoding.
+ * Otherwise, the root directory will be an empty string.
+ *
+ * # Examples (C Code)
+ *
+ * ```
+ * wasm_config_set_module("hello.wasm");
+ * ```
  */
-void wasm_config_clear_mapdirs(void);
+void wasm_config_set_stdin(const unsigned char *buffer,
+                           uintptr_t size);
 
 /**
  * Initialize the Wasm module


### PR DESCRIPTION
Missing feature #13 for reading the HTTP Request Body and putting it into WASI `stdin` so it can be accessible for the WebAssembly modules.

The code for reading the body at `mod_wasm.so` is very tricky.
More info here:
 *  - https://httpd.apache.org/docs/trunk/developer/modguide.html (section: "Reading the request body into memory")
 *  - https://docstore.mik.ua/orelly/apache_mod/139.htm 
