### PR TITLE
Adding preliminary unit tests and integration tests to `wasm_runtime.so`

### DIFF
--- a/.github/workflows/test-wasm_runtime.yml
+++ b/.github/workflows/test-wasm_runtime.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
+    - name: Build
+      working-directory: ./wasm_runtime
+      run: cargo build --verbose
     - name: Run tests
       working-directory: ./wasm_runtime
       run: cargo test --verbose

--- a/.github/workflows/test-wasm_runtime.yml
+++ b/.github/workflows/test-wasm_runtime.yml
@@ -1,0 +1,23 @@
+name: Test `wasm_runtime.so`
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run tests
+      working-directory: ./wasm_runtime
+      run: cargo test --verbose

--- a/wasm_runtime/Cargo.toml
+++ b/wasm_runtime/Cargo.toml
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/wasi"
 
 
 [lib]
-crate-type = ["cdylib"]      # Creates dynamic lib
-#crate-type = ["staticlib"] # Creates static lib
+crate-type = ["cdylib", "rlib"]     # Creates dynamic lib for C ABI (added `rlib` so integration tests can import the `wasm_runtime` crate)
+doctest = false                     # Avoid to run doctest since examples are for C code
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/wasm_runtime/src/config.rs
+++ b/wasm_runtime/src/config.rs
@@ -31,6 +31,11 @@ impl WasmConfig {
     /// Returns Result<(), String>, so that in case of error the String will contain the reason.
     /// 
     pub fn create(config_id: &str) -> Result<(), String> {
+        // safety check for empty id
+        if config_id.len() == 0 {
+            let error_msg = format!("ERROR! Can't create WasmConfig for an empty config_id!");
+            return Err(error_msg);
+        }
                 
         // get write access to the WasmConfig HashMap
         let mut configs = WASM_RUNTIME_CONFIGS.write()

--- a/wasm_runtime/src/ffi_utils.rs
+++ b/wasm_runtime/src/ffi_utils.rs
@@ -114,8 +114,7 @@ mod tests {
     fn const_c_char_to_str_unicode() {
         // setup
         const TESTING_WORDS: &str = "testing 1 2 3! àéïôü";
-        let c_string = CString::new(TESTING_WORDS).expect("FATAL! CString::new() failed!");
-        let const_c_char = c_string.into_raw();
+        let const_c_char: *const c_char = CString::new(TESTING_WORDS).expect("FATAL! CString::new() failed!").into_raw();
 
         // test
         let testing_str = const_c_char_to_str(const_c_char);
@@ -128,8 +127,8 @@ mod tests {
     #[test]
     fn const_c_char_to_str_null_or_empty() {
         // setup
-        let const_c_char_null: *const c_char = ptr::null();
-        let const_c_char_empty = CString::new("").expect("FATAL! CString::new() failed!").into_raw();
+        let const_c_char_null: *const c_char  = ptr::null();
+        let const_c_char_empty: *const c_char = CString::new("").expect("FATAL! CString::new() failed!").into_raw();
 
         // test
         let testing_str_null = const_c_char_to_str(const_c_char_null);
@@ -160,7 +159,7 @@ mod tests {
 
     #[test]
     fn const_c_char_to_str_not_null_terminated() {
-        // setup: non null-terminated C strings
+        // setup: non null-terminated C strings (more than one test, since we don't control rubbish in memory...)
         const TESTING_WORDS_1: &'static [c_char] = &['h' as c_char, 'e' as c_char, 'l' as c_char, 'l' as c_char, 'o' as c_char, '!' as c_char];
         const TESTING_WORDS_2: &'static [c_char] = &['h' as c_char, 'o' as c_char, 'l' as c_char, 'a' as c_char, '!' as c_char];
         const TESTING_WORDS_3: &'static [c_char] = &['h' as c_char, 'i' as c_char, '!' as c_char];

--- a/wasm_runtime/src/ffi_utils.rs
+++ b/wasm_runtime/src/ffi_utils.rs
@@ -159,33 +159,21 @@ mod tests {
 
     #[test]
     fn const_c_char_to_str_not_null_terminated() {
-        // setup: non null-terminated C strings (more than one test, since we don't control rubbish in memory...)
+        // setup: non null-terminated C strings ('*' simulates at least one rubbish byte in memory...)
         const NULL_TERMINATED_1: &'static [c_char] = &['h' as c_char, 'e' as c_char, 'l' as c_char, 'l' as c_char, 'o' as c_char, '\0' as c_char];
-        const NULL_TERMINATED_2: &'static [c_char] = &['h' as c_char, 'i' as c_char, '!' as c_char, '\0' as c_char];
-        const NON_NULL_TERMINATED_1: &'static [c_char] = &['b' as c_char, 'y' as c_char, 'e' as c_char, '!' as c_char];
-        const NON_NULL_TERMINATED_2: &'static [c_char] = &['b' as c_char, 'y' as c_char, 'e' as c_char];
+        const NON_NULL_TERMINATED_1: &'static [c_char] = &['b' as c_char, 'y' as c_char, 'e' as c_char, '!' as c_char, '*' as c_char];
 
         // test
         let null_terminated_1 = const_c_char_to_str(NULL_TERMINATED_1.as_ptr());
         println!("null_terminated_1: {}", null_terminated_1);
         println!("null_terminated_1 len: {}", null_terminated_1.len());
 
-        let null_terminated_2 = const_c_char_to_str(NULL_TERMINATED_2.as_ptr());
-        println!("null_terminated_2: {}", null_terminated_2);
-        println!("null_terminated_2 len: {}", null_terminated_2.len());
-
         let non_null_terminated_1 = const_c_char_to_str(NON_NULL_TERMINATED_1.as_ptr());
         println!("non_null_terminated_1: {}", non_null_terminated_1);
         println!("non_null_terminated_1 len: {}", non_null_terminated_1.len());
 
-        let non_null_terminated_2 = const_c_char_to_str(NON_NULL_TERMINATED_2.as_ptr());
-        println!("non_null_terminated_2: {}", non_null_terminated_2);
-        println!("non_null_terminated_2 len: {}", non_null_terminated_2.len());
-
         // asserts
-        assert_eq!(NULL_TERMINATED_1.len(), null_terminated_1.len() + 1);
-        assert_ne!(NULL_TERMINATED_2.len(), null_terminated_2.len());
-        assert_ne!(NON_NULL_TERMINATED_1.len(), non_null_terminated_1.len());
-        assert_ne!(NON_NULL_TERMINATED_2.len(), non_null_terminated_2.len());
+        assert_eq!(NULL_TERMINATED_1.len() - 1, null_terminated_1.len());
+        assert_ne!(NON_NULL_TERMINATED_1.len() - 1, non_null_terminated_1.len());
     }
 }

--- a/wasm_runtime/src/ffi_utils.rs
+++ b/wasm_runtime/src/ffi_utils.rs
@@ -160,26 +160,32 @@ mod tests {
     #[test]
     fn const_c_char_to_str_not_null_terminated() {
         // setup: non null-terminated C strings (more than one test, since we don't control rubbish in memory...)
-        const TESTING_WORDS_1: &'static [c_char] = &['h' as c_char, 'e' as c_char, 'l' as c_char, 'l' as c_char, 'o' as c_char, '!' as c_char];
-        const TESTING_WORDS_2: &'static [c_char] = &['h' as c_char, 'o' as c_char, 'l' as c_char, 'a' as c_char, '!' as c_char];
-        const TESTING_WORDS_3: &'static [c_char] = &['h' as c_char, 'i' as c_char, '!' as c_char];
+        const NULL_TERMINATED_1: &'static [c_char] = &['h' as c_char, 'e' as c_char, 'l' as c_char, 'l' as c_char, 'o' as c_char, '\0' as c_char];
+        const NULL_TERMINATED_2: &'static [c_char] = &['h' as c_char, 'i' as c_char, '!' as c_char, '\0' as c_char];
+        const NON_NULL_TERMINATED_1: &'static [c_char] = &['b' as c_char, 'y' as c_char, 'e' as c_char, '!' as c_char];
+        const NON_NULL_TERMINATED_2: &'static [c_char] = &['b' as c_char, 'y' as c_char, 'e' as c_char];
 
         // test
-        let testing_str_1 = const_c_char_to_str(TESTING_WORDS_1.as_ptr());
-        println!("testing_str_1: {}", testing_str_1);
-        println!("testing_str_1 len: {}", testing_str_1.len());
+        let null_terminated_1 = const_c_char_to_str(NULL_TERMINATED_1.as_ptr());
+        println!("null_terminated_1: {}", null_terminated_1);
+        println!("null_terminated_1 len: {}", null_terminated_1.len());
 
-        let testing_str_2 = const_c_char_to_str(TESTING_WORDS_2.as_ptr());
-        println!("testing_str_2: {}", testing_str_2);
-        println!("testing_str_2 len: {}", testing_str_2.len());
+        let null_terminated_2 = const_c_char_to_str(NULL_TERMINATED_2.as_ptr());
+        println!("null_terminated_2: {}", null_terminated_2);
+        println!("null_terminated_2 len: {}", null_terminated_2.len());
 
-        let testing_str_3 = const_c_char_to_str(TESTING_WORDS_3.as_ptr());
-        println!("testing_str_3: {}", testing_str_3);
-        println!("testing_str_3 len: {}", testing_str_3.len());
+        let non_null_terminated_1 = const_c_char_to_str(NON_NULL_TERMINATED_1.as_ptr());
+        println!("non_null_terminated_1: {}", non_null_terminated_1);
+        println!("non_null_terminated_1 len: {}", non_null_terminated_1.len());
+
+        let non_null_terminated_2 = const_c_char_to_str(NON_NULL_TERMINATED_2.as_ptr());
+        println!("non_null_terminated_2: {}", non_null_terminated_2);
+        println!("non_null_terminated_2 len: {}", non_null_terminated_2.len());
 
         // asserts
-        assert_ne!(TESTING_WORDS_1.len(), testing_str_1.len());
-        assert_ne!(TESTING_WORDS_2.len(), testing_str_2.len());
-        assert_ne!(TESTING_WORDS_3.len(), testing_str_3.len());
+        assert_eq!(NULL_TERMINATED_1.len(), null_terminated_1.len() + 1);
+        assert_ne!(NULL_TERMINATED_2.len(), null_terminated_2.len());
+        assert_ne!(NON_NULL_TERMINATED_1.len(), non_null_terminated_1.len());
+        assert_ne!(NON_NULL_TERMINATED_2.len(), non_null_terminated_2.len());
     }
 }

--- a/wasm_runtime/src/lib.rs
+++ b/wasm_runtime/src/lib.rs
@@ -13,4 +13,4 @@ mod execution_ctx;
 mod wasm_engine;
 mod wasi_ctx;
 mod ffi_utils;
-mod c_api;
+pub mod c_api;

--- a/wasm_runtime/tests/common/mod.rs
+++ b/wasm_runtime/tests/common/mod.rs
@@ -1,0 +1,17 @@
+//
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! `mod.rs`
+//!
+//! This file contains common functions for integration tests
+
+pub fn setup() {
+    println!("### setup() ###");
+}
+
+pub fn teardown() {
+    println!("### teardown() ###");
+}
+

--- a/wasm_runtime/tests/integration_tests.rs
+++ b/wasm_runtime/tests/integration_tests.rs
@@ -1,0 +1,52 @@
+//
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! `integration_tests.rs`
+//!
+//! This file contains different integration tests
+
+
+mod common;
+
+use std::ffi::{CString, c_char};
+use std::ptr;
+
+use wasm_runtime::c_api;
+
+
+#[test]
+fn wasm_config_create_general() {
+    // setup
+    common::setup();
+    const CONFIG_ID: &'static str = "config_test_id";
+    let config_id = CString::new(CONFIG_ID).expect("FATAL! Can't convert &str into CString!").into_raw();
+
+    // tests
+    let create_result = c_api::wasm_config_create(config_id);
+
+    // asserts
+    assert_eq!(create_result, 0);
+
+    // teardown
+    common::teardown();
+}
+
+#[test]
+fn wasm_config_create_null_or_empty() {
+    // setup
+    let config_id_null: *const c_char = ptr::null();
+    let config_id_empty = CString::new("").expect("FATAL! Can't convert &str into CString!").into_raw();
+
+    // tests
+    let create_result_null = c_api::wasm_config_create(config_id_null);
+    let create_result_empty = c_api::wasm_config_create(config_id_empty);
+
+    // asserts
+    assert_eq!(create_result_null, -1);
+    assert_eq!(create_result_empty, -1);
+
+    // teardown
+    common::teardown();
+}

--- a/wasm_runtime/tests/integration_tests.rs
+++ b/wasm_runtime/tests/integration_tests.rs
@@ -21,7 +21,7 @@ fn wasm_config_create_general() {
     // setup
     common::setup();
     const CONFIG_ID: &'static str = "config_test_id";
-    let config_id = CString::new(CONFIG_ID).expect("FATAL! Can't convert &str into CString!").into_raw();
+    let config_id: *const c_char  = CString::new(CONFIG_ID).expect("FATAL! Can't convert &str into CString!").into_raw();
 
     // tests
     let create_result = c_api::wasm_config_create(config_id);


### PR DESCRIPTION
Fixes #10. The idea is to run preliminary unit tests and integration tests (using GH actions) over `wasm_runtime.so`. Initially, just covers a couple of functions but code coverage will be increased over time.

Running in three different platforms since is testing low-level functions (as `const_c_char_to_str`) that may consider `*const c_char` as i8 or as u8.