### PR TITLE
Support mapping SCRIPT_FILENAME based on WasmMapDirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ To setup and manage WebAssembly binaries and their [WASI](https://wasi.dev/) con
 | `WasmArg <arg>`                | Set an argument to be passed to the Wasm module context. |
 | `WasmEnv <env> <value>`        | Set an environment variable to be passed to the Wasm module context. |
 | `WasmEnableCGI {On\|Off}`      | Enable/Disable CGI emulation mode. Default is `Off`. |
+| `WasmMapCGIFileNames {On\|Off}`| Enable/Disable mapping SCRIPT_FILENAME based on WasmMapDirs when WasmEnableCGI is enabled. Default is `Off`. |
 
 
 ### Workflow

--- a/mod_wasm/docs/manual/mod/mod_wasm.html.en.utf8
+++ b/mod_wasm/docs/manual/mod/mod_wasm.html.en.utf8
@@ -69,6 +69,7 @@
 <li><img alt="" src="../images/down.gif" /> <a href="#wasmdir">WasmDir</a></li>
 <li><img alt="" src="../images/down.gif" /> <a href="#wasmenablecgi">WasmEnableCGI</a></li>
 <li><img alt="" src="../images/down.gif" /> <a href="#wasmenv">WasmEnv</a></li>
+<li><img alt="" src="../images/down.gif" /> <a href="#wasmmapcgifilenames">WasmMapCGIFileNames</a></li>
 <li><img alt="" src="../images/down.gif" /> <a href="#wasmmapdir">WasmMapDir</a></li>
 <li><img alt="" src="../images/down.gif" /> <a href="#wasmmodule">WasmModule</a></li>
 </ul>
@@ -199,13 +200,14 @@ WasmDir /var/www/htdocs/my-site</pre>
 </table>
             <p>            
                 <code class="directive">WasmEnableCGI</code> allows <code class="module"><a href="../mod/mod_wasm.html">mod_wasm</a></code> to connect the HTTP requests with the Wasm module in a CGI-like way:
-                <ul>
-                    <li>HTTP headers from the request are passed to the Wasm module as environmental variables.</li>
-                    <li>HTTP request body is passed to the Wasm module as <em>stdin</em>.</li>
-                    <li>URL query parameters are passed as <code>QUERY_STRING</code> environmental variable.</li>
-                    <li>Output from the Wasm module (<em>stdout</em>) will be parsed and headers such as <code>Content-Type:</code> will be
-                    incorporated into the response headers.</li>
-                </ul>
+            </p>
+            <ul>
+                <li>HTTP headers from the request are passed to the Wasm module as environmental variables.</li>
+                <li>HTTP request body is passed to the Wasm module as <em>stdin</em>.</li>
+                <li>URL query parameters are passed as <code>QUERY_STRING</code> environmental variable.</li>
+                <li>Output from the Wasm module (<em>stdout</em>) will be parsed and headers such as <code>Content-Type:</code> will be incorporated into the response headers.</li>
+            </ul>
+            <p>
                 Default value is <em>Off</em>.
             </p>
             <div class="example"><h3>Example</h3><pre class="prettyprint lang-config">WasmEnableCGI On</pre>
@@ -234,6 +236,32 @@ WasmDir /var/www/htdocs/my-site</pre>
             <div class="example"><h3>Example</h3><pre class="prettyprint lang-config">WasmEnv WEBAPP_SCRIPTS /my-site/scripts
 WasmEnv WEBAPP_DEBUG false</pre>
 </div>
+        
+</div>
+<div class="top"><a href="#page-header"><img alt="top" src="../images/up.gif" /></a></div>
+<div class="directive-section"><h2><a name="WasmMapCGIFileNames" id="WasmMapCGIFileNames">WasmMapCGIFileNames</a> <a name="wasmmapcgifilenames" id="wasmmapcgifilenames">Directive</a> <a title="Permanent link" href="#wasmmapcgifilenames" class="permalink">&para;</a></h2>
+<table class="directive">
+<tr><th><a href="directive-dict.html#Description">Description:</a></th><td>Enable/Disable mapping <code>SCRIPT_FILENAME</code> based on <code>WasmMapDir</code> instances when <code class="directive">WasmEnableCGI</code> is enabled.</td></tr>
+<tr><th><a href="directive-dict.html#Syntax">Syntax:</a></th><td><code>WasmMapCGIFileNames <em>On|Off</em></code></td></tr>
+<tr><th><a href="directive-dict.html#Context">Context:</a></th><td>server config</td></tr>
+<tr><th><a href="directive-dict.html#Status">Status:</a></th><td>Experimental</td></tr>
+<tr><th><a href="directive-dict.html#Module">Module:</a></th><td>mod_wasm</td></tr>
+</table>
+            <p>            
+                <code class="directive">WasmMapCGIFileNames</code> requests <code class="module"><a href="../mod/mod_wasm.html">mod_wasm</a></code> to map `SCRIPT_FILENAME` based on the mapped dirs.
+                Default value is <em>Off</em>.
+            </p>
+            <div class="example"><h3>Example</h3><pre class="prettyprint lang-config">WasmEnableCGI On
+WasmMapCGIFileNames On
+WasmMapDir /app C:/myapp/htdocs</pre>
+</div>
+            <p>
+            In the example, `SCRIPT_FILENAME` will store `/app/index.php` instead of the host path `C:/myapp/htdocs/index.php`.
+            </p><p>
+            Without this setting, we would also need to provide a `WasmDir` granting access to `C:/myapp/htdocs` as the Wasm module would be trying to access it (or setting `WasmMapDir C:/myapp/htdocs C:/myapp/htdocs`).
+            </p><p>
+            In addition, this allows working with a normalized version of the paths, without having to deal with Unix-like or Windows-like filenames.
+            </p>
         
 </div>
 <div class="top"><a href="#page-header"><img alt="top" src="../images/up.gif" /></a></div>

--- a/mod_wasm/docs/manual/mod/mod_wasm.xml
+++ b/mod_wasm/docs/manual/mod/mod_wasm.xml
@@ -272,13 +272,14 @@ WasmEnv WEBAPP_DEBUG false
         <usage>
             <p>            
                 <directive>WasmEnableCGI</directive> allows <module>mod_wasm</module> to connect the HTTP requests with the Wasm module in a CGI-like way:
-                <ul>
-                    <li>HTTP headers from the request are passed to the Wasm module as environmental variables.</li>
-                    <li>HTTP request body is passed to the Wasm module as <em>stdin</em>.</li>
-                    <li>URL query parameters are passed as <code>QUERY_STRING</code> environmental variable.</li>
-                    <li>Output from the Wasm module (<em>stdout</em>) will be parsed and headers such as <code>Content-Type:</code> will be
-                    incorporated into the response headers.</li>
-                </ul>
+            </p>
+            <ul>
+                <li>HTTP headers from the request are passed to the Wasm module as environmental variables.</li>
+                <li>HTTP request body is passed to the Wasm module as <em>stdin</em>.</li>
+                <li>URL query parameters are passed as <code>QUERY_STRING</code> environmental variable.</li>
+                <li>Output from the Wasm module (<em>stdout</em>) will be parsed and headers such as <code>Content-Type:</code> will be incorporated into the response headers.</li>
+            </ul>
+            <p>
                 Default value is <em>Off</em>.
             </p>
             <example><title>Example</title>
@@ -290,6 +291,36 @@ WasmEnableCGI On
                 HTTP request headers are prefixed with '<code>HTTP_</code>', uppercased, and hyphens '<code>-</code>' are substituted by underscores '<code>_</code>' when transformed into environmental variables.
             </p><p>
                 As an example, a header like <code>x-custom-header: value</code> will be transformed into an <code>HTTP_X_CUSTOM_HEADER=value</code> environmental variable.
+            </p>
+        </usage>
+    </directivesynopsis>
+
+    <!-- ************************** WasmMapCGIFileNames ************************* -->
+    <directivesynopsis>
+        <name>WasmMapCGIFileNames</name>
+        <description>Enable/Disable mapping <code>SCRIPT_FILENAME</code> based on <code>WasmMapDir</code> instances when <directive>WasmEnableCGI</directive> is enabled.</description>
+        <syntax>WasmMapCGIFileNames <em>On|Off</em></syntax>
+        <contextlist>
+            <context>server config</context>
+        </contextlist>
+        <usage>
+            <p>            
+                <directive>WasmMapCGIFileNames</directive> requests <module>mod_wasm</module> to map `SCRIPT_FILENAME` based on the mapped dirs.
+                Default value is <em>Off</em>.
+            </p>
+            <example><title>Example</title>
+                <highlight language="config">
+WasmEnableCGI On
+WasmMapCGIFileNames On
+WasmMapDir /app C:/myapp/htdocs
+                </highlight>
+            </example>
+            <p>
+            In the example, `SCRIPT_FILENAME` will store `/app/index.php` instead of the host path `C:/myapp/htdocs/index.php`.
+            </p><p>
+            Without this setting, we would also need to provide a `WasmDir` granting access to `C:/myapp/htdocs` as the Wasm module would be trying to access it (or setting `WasmMapDir C:/myapp/htdocs C:/myapp/htdocs`).
+            </p><p>
+            In addition, this allows working with a normalized version of the paths, without having to deal with Unix-like or Windows-like filenames.
             </p>
         </usage>
     </directivesynopsis>

--- a/wasm_runtime/Cargo.lock
+++ b/wasm_runtime/Cargo.lock
@@ -813,6 +813,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1342,7 @@ dependencies = [
  "anyhow",
  "once_cell",
  "path-clean",
+ "path-slash",
  "rand",
  "wasi-cap-std-sync",
  "wasi-common",

--- a/wasm_runtime/Cargo.lock
+++ b/wasm_runtime/Cargo.lock
@@ -807,6 +807,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1335,7 @@ version = "0.11.3"
 dependencies = [
  "anyhow",
  "once_cell",
+ "path-clean",
  "rand",
  "wasi-cap-std-sync",
  "wasi-common",

--- a/wasm_runtime/Cargo.toml
+++ b/wasm_runtime/Cargo.toml
@@ -25,4 +25,5 @@ anyhow = "1.0.71"
 once_cell = "1.17.1"
 rand = "0.8.5"
 path-clean = "1.0.1"
+path-slash = "0.2.1"
 

--- a/wasm_runtime/Cargo.toml
+++ b/wasm_runtime/Cargo.toml
@@ -24,4 +24,5 @@ wasi-cap-std-sync = "7.0.1"
 anyhow = "1.0.71"
 once_cell = "1.17.1"
 rand = "0.8.5"
+path-clean = "1.0.1"
 

--- a/wasm_runtime/include/wasm_runtime.h
+++ b/wasm_runtime/include/wasm_runtime.h
@@ -156,7 +156,24 @@ int wasm_config_mapdir_add(const char *config_id,
                            const char *map,
                            const char *dir);
 
-const char *wasm_config_get_mapped_path(const char *config_id, const char *path);
+/**
+ * Returns a mapped version of the provided path, based on the current mapdirs
+ *
+ * In case no path is found, it returns null
+ *
+ * Due to String management differences between C and Rust, this function uses `unsafe {}` code.
+ * So `config_id` and `dir` must be a valid pointer to a null-terminated C char array. Otherwise, code might panic.
+ * In addition, `config_id` and `dir` must contain valid ASCII chars that can be converted into UTF-8 encoding.
+ *
+ * # Examples (C Code)
+ *
+ * ```
+ * wasm_config_get_mapped_path("config_id", "/usr/local/apache2");
+ * wasm_config_get_mapped_path("config_id", "c:/app/apache2/htdocs/info.php");
+ * ```
+ */
+const char *wasm_config_get_mapped_path(const char *config_id,
+                                        const char *path);
 
 /**
  * Creates a new Wasm Execution Context for the given Wasm Config identifier.

--- a/wasm_runtime/include/wasm_runtime.h
+++ b/wasm_runtime/include/wasm_runtime.h
@@ -162,8 +162,8 @@ int wasm_config_mapdir_add(const char *config_id,
  * In case no path is found, it returns null
  *
  * Due to String management differences between C and Rust, this function uses `unsafe {}` code.
- * So `config_id` and `dir` must be a valid pointer to a null-terminated C char array. Otherwise, code might panic.
- * In addition, `config_id` and `dir` must contain valid ASCII chars that can be converted into UTF-8 encoding.
+ * So `config_id` and `path` must be a valid pointer to a null-terminated C char array. Otherwise, code might panic.
+ * In addition, `config_id` and `path` must contain valid ASCII chars that can be converted into UTF-8 encoding.
  *
  * # Examples (C Code)
  *

--- a/wasm_runtime/include/wasm_runtime.h
+++ b/wasm_runtime/include/wasm_runtime.h
@@ -156,6 +156,8 @@ int wasm_config_mapdir_add(const char *config_id,
                            const char *map,
                            const char *dir);
 
+const char *wasm_config_get_mapped_path(const char *config_id, const char *path);
+
 /**
  * Creates a new Wasm Execution Context for the given Wasm Config identifier.
  *

--- a/wasm_runtime/src/c_api.rs
+++ b/wasm_runtime/src/c_api.rs
@@ -257,8 +257,7 @@ pub extern "C" fn wasm_config_get_mapped_path(config_id: *const c_char, path: *c
             }
         }
         Err(e) => {
-            let error_msg = format!("ERROR! C-API: Got error while finding mapped path for \'{}\'! {:?}", path_str, e);
-            eprintln!("{}", error_msg);
+            eprintln!("ERROR! C-API: Got error while finding mapped path for \'{}\'! {:?}", path_str, e);
         }
     };
     ptr::null()

--- a/wasm_runtime/src/c_api.rs
+++ b/wasm_runtime/src/c_api.rs
@@ -231,21 +231,38 @@ pub extern "C" fn wasm_config_mapdir_add(config_id: *const c_char, map: *const c
     }  
 }
 
+/// Returns a mapped version of the provided path, based on the current mapdirs
+///
+/// In case no path is found, it returns null
+///
+/// Due to String management differences between C and Rust, this function uses `unsafe {}` code.
+/// So `config_id` and `path` must be a valid pointer to a null-terminated C char array. Otherwise, code might panic.
+/// In addition, `config_id` and `path` must contain valid ASCII chars that can be converted into UTF-8 encoding.
+///
+/// # Examples (C Code)
+///
+/// ```
+/// wasm_config_get_mapped_path("config_id", "/usr/local/apache2");
+/// wasm_config_get_mapped_path("config_id", "c:/app/apache2/htdocs/info.php");
+/// ```
 #[no_mangle]
 pub extern "C" fn wasm_config_get_mapped_path(config_id: *const c_char, path: *const c_char) -> *const c_char {
     let config_id_str = const_c_char_to_str(config_id);
-    let path_str       = const_c_char_to_str(path);
+    let path_str      = const_c_char_to_str(path);
 
     match WasmConfig::get_mapped_path(config_id_str, path_str) {
-        Some(str) => {
-              str_to_c_char(&str)
-        },
-        None => {
-                 ptr::null()
+        Ok(r) => {
+            if let Some(result) = r {
+                return str_to_c_char(&result);
+            }
         }
-    }
+        Err(e) => {
+            let error_msg = format!("ERROR! C-API: Got error while finding mapped path for \'{}\'! {:?}", path_str, e);
+            eprintln!("{}", error_msg);
+        }
+    };
+    ptr::null()
 }
-
 
 /// Creates a new Wasm Execution Context for the given Wasm Config identifier.
 ///

--- a/wasm_runtime/src/c_api.rs
+++ b/wasm_runtime/src/c_api.rs
@@ -13,7 +13,7 @@ use crate::module::WasmModule;
 use crate::config::WasmConfig;
 use crate::execution_ctx::WasmExecutionCtx;
 use crate::ffi_utils::*;
-
+use std::ptr;
 
 /// Load a Wasm Module from disk.
 ///
@@ -229,6 +229,21 @@ pub extern "C" fn wasm_config_mapdir_add(config_id: *const c_char, map: *const c
             -1
         }
     }  
+}
+
+#[no_mangle]
+pub extern "C" fn wasm_config_get_mapped_path(config_id: *const c_char, path: *const c_char) -> *const c_char {
+    let config_id_str = const_c_char_to_str(config_id);
+    let path_str       = const_c_char_to_str(path);
+
+    match WasmConfig::get_mapped_path(config_id_str, path_str) {
+        Some(str) => {
+              str_to_c_char(&str)
+        },
+        None => {
+                 ptr::null()
+        }
+    }
 }
 
 

--- a/wasm_runtime/src/config.rs
+++ b/wasm_runtime/src/config.rs
@@ -14,6 +14,7 @@ use std::sync::RwLock;
 use std::path::{Path, PathBuf};
 use once_cell::sync::Lazy;
 use path_clean::clean;
+use path_slash::PathBufExt as _;
 
 pub struct WasmConfig {
     pub id:           String,
@@ -210,44 +211,41 @@ impl WasmConfig {
         wasm_config.wasi_mapdirs.push((wasi_map.to_string(), wasi_dir.to_string()));
         Ok(())
     }
-    // Returns a version of path with all slashes converted to forward
-    fn path_to_unix_slashes(path: &Path) -> String {
-        path.to_string_lossy().into_owned().replace("\\", "/")
-    }
-    fn find_longest_map(mapdirs: &[(String, String)], path: &str) -> Option<String> {
-        let cleaned_path = clean(Self::path_to_unix_slashes(Path::new(path)));
-        let mut ordered = mapdirs.to_vec();
-        ordered.sort_by_key(|(_, from)| Path::new(from).components().count());
-        let longest_map = ordered
-            .iter()
-            .rev()
-            .find(|(_, from)| cleaned_path.starts_with(from))
-            .and_then(|(to, from)| match cleaned_path.strip_prefix(from) {
-                Ok(tail) => Some(PathBuf::from(to).join(tail)),
-                Err(_) => None,
-            });
 
-        longest_map.map(|p| Self::path_to_unix_slashes(clean(p).as_path()))
-    }
-
-    pub fn get_mapped_path(config_id: &str, path: &str) -> Option<String> {
-        let configs = match WASM_RUNTIME_CONFIGS.read() {
-            Ok(c) => c,
-            Err(_) => {
-                return None;
-            }
-        };
+    pub fn get_mapped_path(config_id: &str, path: &str) -> Result<Option<String>, String> {
+        let configs = WASM_RUNTIME_CONFIGS
+            .read()
+            .expect("ERROR! Poisoned RwLock WASM_RUNTIME_CONFIGS on read()");
 
         let wasm_config = match configs.get(config_id) {
             Some(c) => c,
             None => {
-                return None;
+                let error_msg = format!("Wasm config \'{}\' not created previously!", config_id);
+                return Err(error_msg);
             }
         };
-        Self::find_longest_map(&wasm_config.wasi_mapdirs, path)
+        Ok(Self::find_longest_map(&wasm_config.wasi_mapdirs, path))
+    }
+
+    fn normalize_path(path: &str) -> String {
+        return clean(path).to_slash_lossy().to_string()
+    }
+
+    fn find_longest_map(mapdirs: &[(String, String)], path: &str) -> Option<String> {
+        let cleaned_path = PathBuf::from(Self::normalize_path(&path));
+
+        let longest_map = mapdirs
+        .iter()
+        .filter(|(_, from)| cleaned_path.starts_with(from))
+        .max_by_key(|(_, from)| Path::new(from).components().count())
+        .and_then(|(to, from)| match cleaned_path.strip_prefix(from) {
+            Ok(tail) =>  Some(format!("{}/{}", to, tail.to_string_lossy())),
+            Err(_) => None,
+        });
+
+        longest_map.map(|p| Self::normalize_path(&p))
     }
 }
-
 
 // The following static variable is used to achieve a global, mutable and thread-safe shareable state.
 // For that given purpose, it uses [Once Cell](https://crates.io/crates/once_cell).


### PR DESCRIPTION
This PR allows instructing Apache to provide the wasm module with a mapped version of SCRIPT_FILENAME based on the configured WasmMapDir directories:

```
WasmEnableCGI On
# Map the filenames
WasmMapCGIFileNames On
WasmMapDir /app c:/myapp/htdocs
```

Will set `SCRIPT_FILENAME` to `/app/index.php` instead of the host path  `c:/myapp/htdocs/index.php`

Without this setting, we would also need to provide a WasmDir granting access to `c:/myapp/htdocs` as the wasm module would be trying to access it (or do `WasmMapDir c:/myapp/htdocs c:/myapp/htdocs`).

In addition, this allows working with a normalized version of the paths, without having to deal with unix-like or windows-like filenames.