### PR TITLE
Remove hardcoded values from the build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ container-image:
 	docker build -f image/Dockerfile -t httpd-mod-wasm:latest .
 
 container-multi-arch-image:
-	docker buildx build --platform linux/arm64/v8,linux/amd64 -f image/Dockerfile -t ghcr.io/vmware-labs/httpd-mod-wasm:latest .
+	docker buildx build --progress=plain --platform linux/arm64/v8,linux/amd64 -f image/Dockerfile -t ghcr.io/vmware-labs/httpd-mod-wasm:latest .
 
 push-container-multi-arch-image:
-	docker buildx build --platform linux/arm64/v8,linux/amd64 -f image/Dockerfile -t ghcr.io/vmware-labs/httpd-mod-wasm:latest --push .
+	docker buildx build --progress=plain --platform linux/arm64/v8,linux/amd64 -f image/Dockerfile -t ghcr.io/vmware-labs/httpd-mod-wasm:latest --push .
 
 dev-image:
 	docker build -f image/Dockerfile.dev -t httpd-mod-wasm-dev:latest .

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -35,7 +35,7 @@ COPY ./dist $DIST_DIR
 COPY --from=builder-wasm_runtime.so $WASM_RUNTIME_PATH/target/release/libwasm_runtime.so $WASM_RUNTIME_PATH/target/release/libwasm_runtime.so
 COPY --from=builder-wasm_runtime.so $WASM_RUNTIME_PATH/include/ $WASM_RUNTIME_PATH/include/
 RUN mkdir -p $MOD_WASM_PATH/dist/conf $DIST_DIR/modules
-RUN HTTPD_DIR=/usr/local/apache2 ./build.sh
+RUN ./build.sh
 
 
 ################################################################################

--- a/mod_wasm/build.sh
+++ b/mod_wasm/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #################################################################################
 # mod_wasm should be compiled in the Apache environment using Autoconf/Automake.
@@ -6,13 +6,20 @@
 # This build.sh script is just a shortcut for development purposes.
 #################################################################################
 
-env
 set -x
 
+CC="${CC:-gcc}"
+LIBTOOL="${LIBTOOL:-$(which libtool)}"
+HTTPD_DIR="${HTTPD_DIR:-/usr/include/apache2}"
+
 # check dependencies
-if ! which libtool; then
+if [[ ! -e "$LIBTOOL" ]]; then
     echo "libtool not found; please, install it"
     exit 1
+fi
+
+if [[ -d /usr/share/apr-1.0/build ]]; then
+    export PATH=/usr/share/apr-1.0/build:$PATH
 fi
 
 if ! which pkg-config; then
@@ -27,12 +34,6 @@ SCRIPT_DIR=$( cd -- "$(dirname -- "$0")" &> /dev/null && pwd )
 MOD_WASM_DIR=${MOD_WASM_DIR:-$(realpath "${SCRIPT_DIR}/modules/wasm")}
 WASM_RUNTIME_PATH=${WASM_RUNTIME_PATH:-$(realpath "${SCRIPT_DIR}/../wasm_runtime")}
 DIST_DIR=${DIST_DIR:-$(realpath "${SCRIPT_DIR}/../dist")}
-if [ -z ${HTTPD_DIR} ]
-then
-    HTTPD_DIR=$(realpath ../httpd)
-    echo "\$HTTPD_DIR not defined! Using by default: $HTTPD_DIR"
-fi
-ARCH=$(uname -m)
 
 echo "[Deleting binaries]"
 
@@ -51,23 +52,31 @@ echo "[Building mod_wasm]"
 echo "[mod_wasm: compiling]"
 cd ${MOD_WASM_DIR}
 
-/usr/share/apr-1.0/build/libtool --verbose --mode=compile ${ARCH}-linux-gnu-gcc \
-     -I${HTTPD_DIR}/include \
-     -I${HTTPD_DIR}/dist/include \
+INCLUDE_PATHS=( "-I${HTTPD_DIR}" )
+# In case HTTP_DIR is pointing to the HTTPD full repository
+if [[ -d "${HTTPD_DIR}/include" ]]; then
+    INCLUDE_PATHS+=( "-I${HTTPD_DIR}/include" )
+fi
+# In case HTTP_DIR is pointing to the HTTPD full repository
+if [[ -d "${HTTPD_DIR}/dist/include" ]]; then
+    INCLUDE_PATHS+=( "-I${HTTPD_DIR}/dist/include" )
+fi
+${LIBTOOL} --verbose --mode=compile ${CC} \
      $(pkg-config --cflags apr-1 apr-util-1) \
+     ${INCLUDE_PATHS} \
      -I${WASM_RUNTIME_PATH}/include \
      -shared \
      -c mod_wasm.c && touch mod_wasm.slo
 
 echo "[mod_wasm: linking]"
-/usr/share/apr-1.0/build/libtool --verbose --mode=link ${ARCH}-linux-gnu-gcc \
+${LIBTOOL} --verbose --mode=link ${CC} \
      -L${WASM_RUNTIME_PATH}/target/release -lwasm_runtime \
      -o mod_wasm.la \
      -rpath ${HTTP_SERVER_PATH}/dist/modules \
      -module -avoid-version mod_wasm.lo
 
 echo "[Installing module]"
-mkdir -p "${DIST_DIR}/modules/" 
+mkdir -p "${DIST_DIR}/modules/"
 cp -v .libs/mod_wasm.so "${DIST_DIR}/modules/"
 
 echo "[Installing httpd.conf]"

--- a/wasm_runtime/include/wasm_runtime.h
+++ b/wasm_runtime/include/wasm_runtime.h
@@ -1,6 +1,6 @@
 /* See doc at: https://github.com/eqrion/cbindgen/blob/master/docs.md#cbindgentoml
 
-/* Generated with cbindgen:0.24.3 */
+/* Generated with cbindgen:0.26.0 */
 
 #include <stdarg.h>
 #include <stdbool.h>


### PR DESCRIPTION
This removes some assumptions about the compiler executable name as well as the path where to find libtool.

This enables the nix expression https://github.com/ereslibre/nixities/blob/aba33822dd441076bca71bc2763bb2cd56ad80e3/shells/work/mod-wasm/default.nix to create a shell to build the project.

This also removes the need for having the whole httpd project cloned in order to build and link mod_wasm.