### PR TITLE
Add WasmEntryPoint directive to change/specify entrypoints

### DIFF
--- a/mod_wasm/httpd.conf
+++ b/mod_wasm/httpd.conf
@@ -187,6 +187,7 @@ LoadModule wasm_module modules/mod_wasm.so
     <Location /hello-wasm>
         SetHandler wasm-handler
         WasmModule /usr/local/apache2/wasm_modules/rust-wasm/hello_wasm.wasm
+        WasmEntryPoint _start
     </Location>
 
     ###################################################################

--- a/mod_wasm/modules/wasm/mod_wasm.c
+++ b/mod_wasm/modules/wasm/mod_wasm.c
@@ -435,6 +435,7 @@ static void register_hooks(apr_pool_t *p)
 #define WASM_DIRECTIVE_WASMMAPDIR           "WasmMapDir"
 #define WASM_DIRECTIVE_WASMENABLECGI        "WasmEnableCGI"
 #define WASM_DIRECTIVE_WASMMAPCGIFILENAMES  "WasmMapCGIFileNames"
+#define WASM_DIRECTIVE_WASMENTRYPOINT       "WasmEntryPoint"
 
 static const char *wasm_directive_WasmModule(cmd_parms *cmd, void *mconfig, const char *word1)
 {
@@ -518,6 +519,17 @@ static const char *wasm_directive_WasmMapCGIFileNames(cmd_parms *cmd, void *mcon
     return NULL;
 }
 
+static const char *wasm_directive_WasmEntryPoint(cmd_parms *cmd, void *mconfig, const char *entrypoint)
+{
+    x_cfg *cfg = (x_cfg *) mconfig;
+    int ret = wasm_config_entrypoint_set(cfg->loc, entrypoint);
+    if ( ret != OK )
+        ap_log_error(APLOG_MARK, APLOG_ERR, ret, NULL,
+            "wasm_directive_WasmEntryPoint() - ERROR! Couldn't set entrypoint '%s' to Wasm config '%s'!", entrypoint, cfg->loc);
+
+    return NULL;
+}
+
 /*
  * List of directives specific to our module.
  */
@@ -542,7 +554,7 @@ static const command_rec directives[] =
         wasm_directive_WasmEnv,
         NULL,
         OR_OPTIONS,
-        "Set environtment variable for the Wasm Module"
+        "Set environment variable for the Wasm Module"
     ),
     AP_INIT_TAKE1(
         WASM_DIRECTIVE_WASMDIR,
@@ -571,6 +583,13 @@ static const command_rec directives[] =
         NULL,
         OR_OPTIONS,
         "Whether SCRIPT_FILENAME should be mapped based on WasmMapDir mounts when running as a CGI"
+    ),
+    AP_INIT_TAKE1(
+        WASM_DIRECTIVE_WASMENTRYPOINT,
+        wasm_directive_WasmEntryPoint,
+        NULL,
+        OR_OPTIONS,
+        "Set entrypoint for the Wasm Module"
     ),
     {NULL}
 };

--- a/wasm_runtime/src/execution_ctx.rs
+++ b/wasm_runtime/src/execution_ctx.rs
@@ -28,6 +28,7 @@ pub struct WasmExecutionCtx {
     pub wasi_mapdirs: Vec<(String, String)>,
     pub wasi_stdin:   Vec<u8>,
     pub wasi_stdout:  Arc<RwLock<Vec<u8>>>,
+    pub entrypoint:   String
 }
 
 impl WasmExecutionCtx {
@@ -65,6 +66,7 @@ impl WasmExecutionCtx {
             wasi_mapdirs: wasm_config.wasi_mapdirs.clone(),
             wasi_stdin:   Vec::new(),
             wasi_stdout:  Arc::new(RwLock::new(Vec::new())),
+            entrypoint:   wasm_config.entrypoint.clone()
         };
 
         Self::try_insert(wasm_executionctx)
@@ -154,8 +156,8 @@ impl WasmExecutionCtx {
             }
         };
         
-        // invoke default "_start" function for the given Wasm execution context
-        wasm_engine::invoke_wasm_function(&wasm_executionctx, "_start")?;
+        // invoke entrypoint for the given Wasm execution context (default is "_start")
+        wasm_engine::invoke_wasm_function(&wasm_executionctx, &wasm_executionctx.entrypoint)?;
 
         // read stdout from the Wasm execution context and return it
         let wasm_module_stdout = Self::read_stdout(&wasm_executionctx);


### PR DESCRIPTION
Adds the `WasmEntryPoint` directive described in #25. The entrypoint still defaults to `_start`

1. `WasmEntryPoint` directive sets a new `entrypoint` field to `WasmConfig`
2.  `WasmConfig` assigns the `entrypoint` field to the `WasmExecutionCtx`
3.  The specified `entrypoint` is invoked by `WasmExecutionCtx::run`.