### PR TITLE
fix: Completes code coverage for `module.rs`

### DIFF
--- a/wasm_runtime/src/module.rs
+++ b/wasm_runtime/src/module.rs
@@ -109,9 +109,21 @@ mod tests {
     }
 
     #[test]
-    fn test_load_from_file_failure() {
+    fn test_load_from_file_failure_nonexistent() {
         // setup non-existent path
         const PATH: &str = "../attempt/to/load/me.wasm";
+
+        // execute test of failed load
+        let res = WasmModule::load_from_file(PATH);
+
+        // test assertion
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_load_from_file_failure_fakefile() {
+        // setup fake path
+        const PATH: &str = "../examples/wasm_modules/rust-wasm/fake.wasm";
 
         // execute test of failed load
         let res = WasmModule::load_from_file(PATH);


### PR DESCRIPTION
Completing works from @dpfens to achieve 100% code coverage over `module.rs`.
Adding unit test for `load_from_file()` when the file exists but it is not a `.wasm` binary.